### PR TITLE
Prevent LF normalization for VBA files in git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,11 @@
 *.dll filter=lfs diff=lfs merge=lfs -text
 *.mvba filter=lfs diff=lfs merge=lfs -text
 
+# VBA extensions: Prevent LF normalization (VBE requires CRLF)
+*.bas -text
+*.cls -text
+*.frm -text
+
 # Force binary for these files
 *.png binary
 *.jpg binary

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Invoke-WebRequest -Uri "https://github.com/Asketyll/ARES/releases/download/insta
 | Component | Release | Description |
 |-----------|---------|-------------|
 | [Installer](https://github.com/Asketyll/ARES/releases/tag/installer-v1.0.0) | `installer-v1.0.0` | Windows installer with automatic setup |
-| [MVBA](https://github.com/Asketyll/ARES/releases/latest) | `v1.0.0` | MicroStation VBA source code |
+| [MVBA](https://github.com/Asketyll/ARES/releases/latest) | `v1.0.1` | MicroStation VBA source code |
 
 ## Components
 


### PR DESCRIPTION
## Summary
Updated `.gitattributes` to prevent Git from normalizing line endings in VBA source files. VBA files require CRLF line endings to function properly in the Visual Basic Editor (VBE).

## Changes
- Added `-text` attribute to `.bas`, `.cls`, and `.frm` VBA file extensions
- This prevents Git from converting CRLF to LF on checkout and LF to CRLF on commit
- Ensures VBA files maintain their required CRLF line endings across all environments and operations
- Update master README.md

## Details
VBA source files (Basic modules, Class modules, and Forms) are sensitive to line ending formats. The Visual Basic Editor requires CRLF line endings to properly parse and execute these files. By marking them with `-text`, we ensure that Git treats them as binary-like files with respect to line ending normalization, preserving the exact line endings committed to the repository.
